### PR TITLE
Fixed physgun/gravgun name display

### DIFF
--- a/karmahud/lua/karmahud/client/cl_karmahud.lua
+++ b/karmahud/lua/karmahud/client/cl_karmahud.lua
@@ -151,6 +151,12 @@ hook.Add( "HUDPaint", "KarmaHUD:DrawHisShiteHUD", function()
 	if IsValid(LocalPlayer():GetActiveWeapon()) then
 		local wep = LocalPlayer():GetActiveWeapon()
 		local wep_name = wep.PrintName or wep:GetPrintName() or wep:GetClass()
+    if wep_name == "#HL2_GravityGun" then
+      wep_name = "Gravity Gun"
+    end
+    if wep_name == "#GMOD_Physgun" then
+      wep_name = "Physics Gun"
+    end
 		draw.SimpleText(wep_name, "KarmaHUD_Font1", 70, ScrH() - 100, KarmaHUD.Config.HUDFontColor, TEXT_ALIGN_CENTER, TEXT_ALIGN_CENTER)
 	end
 		


### PR DESCRIPTION
Added conditional statements to replace the default strings of (#HL2_GravityGun / #GMOD_Physgun) to their correct names.